### PR TITLE
feat(DOM) also return root element when creating a document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ yet. Scan the code for `"TODO:"` to see what is still to be done.
 
 ```lua
 local DOM = require("expadom.DOMImplementation")()
-local doc = DOM:createDocument(nil, "root")
-local root = doc.documentElement
+local doc, root = DOM:createDocument(nil, "root")
 root:appendChild(doc:createComment("let's create an address list"))
 local list = doc:createElement("addresses")
 list:setAttribute("country", "Netherlands")
@@ -70,6 +69,12 @@ dependencies will be dealt with by LuaRocks.
 The project is licensed under the [MIT License](https://github.com/lunarmodules/expadom/blob/main/LICENSE)
 
 ## History
+
+#### unreleased
+
+* Feat: return root element as well when creating a document (DOMimplementation)
+  [#5](https://github.com/lunarmodules/expadom/pull/5)
+
 
 #### 22-Apr-2022 0.1.0 Initial release
 

--- a/docs_topics/01-Introduction.md
+++ b/docs_topics/01-Introduction.md
@@ -21,8 +21,7 @@ can be used to create all sorts of children and build the document;
 
 ```lua
 local DOM = require("expadom.DOMImplementation")()
-local doc = DOM:createDocument(nil, "root")
-local root = doc.documentElement
+local doc, root = DOM:createDocument(nil, "root")
 root:appendChild(doc:createTextNode("hello world"))
 ```
 

--- a/spec/02-DOM/02-DOMImplementation_spec.lua
+++ b/spec/02-DOM/02-DOMImplementation_spec.lua
@@ -53,12 +53,13 @@ describe("DOMImplementation:", function()
 
 		it("creates a new instance", function()
 			local doctype = assert(DOM:createDocumentType("prefix:name", "pubid", "sysid"))
-			local doc = assert(DOM:createDocument("http://example.dev/some/path", "ns:root", doctype))
+			local doc, root = assert(DOM:createDocument("http://example.dev/some/path", "ns:root", doctype))
 
 			assert(Class.is_instance_of(Document, doc))
 
 			assert.equal(DOM, doc.implementation)
 			assert.equal(doctype, doc.doctype)
+			assert.equal(root, doc.documentElement)
 			assert.equal("ns", doc.documentElement.prefix)
 			assert.equal("root", doc.documentElement.localName)
 			assert.equal("ns:root", doc.documentElement.tagName)

--- a/src/expadom/DOMImplementation.lua
+++ b/src/expadom/DOMImplementation.lua
@@ -26,15 +26,16 @@ end
 
 
 --- Creates a new Document instance, implements [createDocument](https://www.w3.org/TR/DOM-Level-2-Core/#core-Level-2-Core-DOM-createDocument).
+-- In addition to the Core spec, it also returns a second return value, the `documentElement` created.
 -- @tparam string|nil namespaceURI (required if the `qualifiedName` has a prefix)
 -- @tparam string qualifiedName the `tagName` of the top element, can have a prefix.
 -- @tparam[opt] DocumentType doctype a DocumentType instance.
--- @return a new Document instance
+-- @return a new Document instance + the `documentElement`
 -- @usage
 -- local DOM = require("expadom.DOMImplementation")()  -- create an instance
--- local doc1 = DOM:createDocument(nil, "root")                       -- plain root element
--- local doc2 = DOM:createDocument("http://namespace", "prefix:root") -- namespaced root element
--- local doc3 = DOM:createDocument("http://namespace", "root")        -- root element with default namespace
+-- local doc1, root1 = DOM:createDocument(nil, "root")                       -- plain root element
+-- local doc2, root2 = DOM:createDocument("http://namespace", "prefix:root") -- namespaced root element
+-- local doc3, root3 = DOM:createDocument("http://namespace", "root")        -- root element with default namespace
 function methods:createDocument(namespaceURI, qualifiedName, doctype)
 	if doctype ~= nil then
 		if not Class.is_instance_of(DocumentType, doctype) then
@@ -68,7 +69,7 @@ function methods:createDocument(namespaceURI, qualifiedName, doctype)
 	end
 
 	doc:appendChild(root_elem)
-	return doc
+	return doc, root_elem
 end
 
 


### PR DESCRIPTION
Convenience, since typically first thing after creating would be
getting the root element to add stuff.